### PR TITLE
fix: use type narrowing & more precise types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "minima.js",
-  "version": "0.96.8",
+  "name": "minima",
+  "version": "0.96.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/minima.ts
+++ b/src/minima.ts
@@ -258,7 +258,7 @@ interface State {
 	keeper: string
 }
 
-type Callback = (jsonresp: any) => void
+type Callback = (jsonresp: unknown) => void
 
 /**
  * The MAIN Minima Callback function
@@ -379,7 +379,7 @@ const Minima = {
 
 		//Any Parameters..
 		const paramstring = Minima.webhost+"/params";
-		httpGetAsync(paramstring, function (jsonresp: any) {
+		httpGetAsync(paramstring, function (jsonresp: unknown) {
 			//Set it..
 			MINIMA_PARAMS = jsonresp;
 		});
@@ -652,10 +652,9 @@ const Minima = {
 
 }
 
-/**
- * POST the RPC call - can be cmd/sql/file/net
- */
-function MinimaRPC(type: string, data: string, callback: (jsonresp: any) => void = () => {}): void {
+type RPCType = "cmd" | "sql" | "file" | "net";
+
+function MinimaRPC(type: RPCType, data: string, callback: Callback = () => {}): void {
 	//And now fire off a call saving it
 	httpPostAsync(Minima.rpchost+"/"+type+"/"+Minima.minidappid, encodeURIComponent(data), callback);
 }
@@ -850,7 +849,7 @@ function httpPostAsync(theUrl: string, params: string, callback: Callback): void
  * @param callback
  * @returns
  */
-function httpGetAsync(theUrl: string, callback: (jsonresp: any) => void, logenabled: boolean = false): void {
+function httpGetAsync(theUrl: string, callback: Callback, logenabled: boolean = false): void {
 		const xmlHttp = new XMLHttpRequest();
 		xmlHttp.onreadystatechange = function () {
 				if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {


### PR DESCRIPTION
This narrows down the RPC types to what the comment specifies, effectively making it obsolete and actually enforced.

Literal values are their own types, which means we can specify these unions of literals just fine.

The `Callback` signature is also very naïve. `any` is not a useful type, but rather just a way to turn off the type system when there is a lack of understanding of what's going on. A callback taking JSON data of an unknown shape should instead be specified as taking `unknown`, which means the callback itself will have to ascertain what the shape of the data is, via type guards.

`unknown` is effectively a version of `any` that cannot be passed to something requiring a more specific type, which means it's a type-safe way to refer to data that is of **unknown** shape.

Further work on the RPC functions should probably be done, with a union of possible commands being created (which would also then remove the need for the stringly typed `data` parameter). In general, the code, small as it is, is full of places where thinking about the possible values of things and actually nailing these down could be useful.

It's clear, for example, that there is a valid set of inputs and a shape to `jmsg` in the code, except the expectation is never validated or otherwise established. `JSON.parse` is a nebulous function to use for these things, as it returns `any`. This illustrates the issue with letting `any` into the codebase. If it returned `unknown`, the code would instead have to actually establish that it's dealing with the correct data.

`any` is also used for `MINIMA_PARAMS` in place of a more precise type. I believe this is likely the reason for the nonsensical `return MINIMA_PARAMS[paramname]` in a function that returns `void` (`form.params`, `minima.ts:555`).